### PR TITLE
Default driver type def fix

### DIFF
--- a/src/Locker.ts
+++ b/src/Locker.ts
@@ -20,7 +20,7 @@ export const LOCKER_DEFAULT_CONFIG_PROVIDER = {
 
 export interface ILockerConfig {
   driverNamespace?: string
-  defaultDriverType?: Driver|Driver
+  defaultDriverType?: Driver|Driver[]
   namespaceSeparator?: string
 }
 


### PR DESCRIPTION
Version 1.0.0 (current npm release).

This is causing build to fail when using multiple fallback drivers.  The code fix is very minor, but I figured I make the PR anyways: https://github.com/MikaAK/angular-safeguard/blob/1.0.0/src/Locker.ts#L23

We don't have a 1.x branch to make PR to so I'll put it at master for now.